### PR TITLE
This resolves rare desk stuttering during movement

### DIFF
--- a/linak_controller/desk.py
+++ b/linak_controller/desk.py
@@ -63,7 +63,7 @@ class Desk:
 
         while True:
             await ReferenceInputService.ONE.write(client, data)
-            await asyncio.sleep(0.4)
+            await asyncio.sleep(0.3)
             height, speed = await ReferenceOutputService.get_height_speed(client)
             if speed.value == 0:
                 break

--- a/linak_controller/gatt.py
+++ b/linak_controller/gatt.py
@@ -93,7 +93,7 @@ class ReferenceInputService(Service):
 
         while True:
             await cls.ONE.write(client, data)
-            await asyncio.sleep(0.4)
+            await asyncio.sleep(0.3)
             height, speed = await ReferenceOutputService.get_height_speed(client)
             if speed.value == 0:
                 break


### PR DESCRIPTION
More details in previous PR: https://github.com/rhyst/linak-controller/pull/73

It appears that 0.3s is better than 0.4s, as there are occasional desk stutters with 0.4s, as shown here:
```
Height:  918mm Speed: -62mm/s
Height:  892mm Speed: -62mm/s
Height:  874mm Speed: -6mm/s // <-- stuttering
Height:  864mm Speed: -45mm/s // <-- stuttering
Height:  842mm Speed: -62mm/s
Height:  817mm Speed: -62mm/s
```