### PR TITLE
Fixing error: --move-command-period: invalid int value: '0.3'

### DIFF
--- a/linak_controller/config.py
+++ b/linak_controller/config.py
@@ -96,7 +96,7 @@ class Config:
         parser.add_argument(
             "--move-command-period",
             dest="move_command_period",
-            type=int,
+            type=float,
             help="The period between each move command (seconds)",
         )
         parser.add_argument(


### PR DESCRIPTION
"--move-command-period" accepted only integer values; it should also allow float values.