### PR TITLE
Enable watch mode when using --server

### DIFF
--- a/linak_controller/main.py
+++ b/linak_controller/main.py
@@ -180,7 +180,7 @@ async def run_forwarded_ws_command(client: BleakClient, request):
 
 async def forward_command():
     """Send commands to a server instance of this script"""
-    allowed_commands = [None, Commands.move_to]
+    allowed_commands = [None, Commands.move_to, Commands.watch]
     if config.command not in allowed_commands:
         print(f"Command must be one of {allowed_commands}")
         return


### PR DESCRIPTION
Watch mode works over --forward, just needed to be enabled.