### PR TITLE
Argument --server_port should be --server-port

### DIFF
--- a/linak_controller/config.py
+++ b/linak_controller/config.py
@@ -112,7 +112,7 @@ class Config:
             help="The address the server should run at",
         )
         parser.add_argument(
-            "--server_port",
+            "--server-port",
             dest="server_port",
             type=int,
             help="The port the server should run on",


### PR DESCRIPTION
As stated in readme:

```
All of these options (except favourites) can be set on the command line, just replace any _ with - e.g. mac_address becomes --mac-address.
```

Is currently not true for `server_port`.