### PR TITLE
Add Python 3.14 support

### DIFF
--- a/linak_controller/config.py
+++ b/linak_controller/config.py
@@ -26,19 +26,17 @@ class Commands(str, Enum):
     tcp_server = "tcp_server"
 
 
-Config = TypedDict(
-    "Config",
-    mac_address=Optional[str],
-    base_height=Optional[int],
-    adapter_name=str,
-    scan_timeout=int,
-    connection_timeout=int,
-    server_address=str,
-    server_port=int,
-    favourites=dict,
-    forward=bool,
-    move_command_period=float,
-)
+class Config(TypedDict):
+    mac_address: Optional[str]
+    base_height: Optional[int]
+    adapter_name: str
+    scan_timeout: int
+    connection_timeout: int
+    server_address: str
+    server_port: int
+    favourites: dict
+    forward: bool
+    move_command_period: float
 
 default_config = Config(
     {
@@ -55,11 +53,9 @@ default_config = Config(
     }
 )
 
-Command = TypedDict(
-    "Command",
-    key=Optional[Commands],
-    value=Optional[str],
-)
+class Command(TypedDict):
+    key: Optional[Commands]
+    value: Optional[str]
 
 
 def get_config() -> tuple[Config, Command]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ authors = ["Rhys Tyers"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.14"
+python = ">=3.9"
 aiohttp = "^3.8.4"
 appdirs = "^1.4.4"
-bleak = "^0.22.3"
+bleak = "^1.1.1"
 PyYAML = "^6.0"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Bumped bleak to the latest release, 1.1.1 which has a minimum requirement of python 3.9.
Changed class syntax to run on the newer python release.